### PR TITLE
Changed $R --vanilla to $R --no-save --no-restore

### DIFF
--- a/crant
+++ b/crant
@@ -198,7 +198,7 @@ do_roxygenize()
 {
   if [ -n "$roxygen" ]; then
     printf "Roxygenizing %s\n" $package >> /dev/stderr
-    echo "library(roxygen2); roxygenize('.')" | $R --vanilla
+    echo "library(roxygen2); roxygenize('.')" | $R --no-save --no-restore
     check_fatal "Error executing roxygenize"
     [ -z "$1" ] && commit "Roxygenize" man DESCRIPTION NAMESPACE
   fi


### PR DESCRIPTION
Some users may install packages in a non-default directory which is specified in the .Renviron or R site script. With the --vanilla switch, these files are not read so the required package is not found.
