### PR TITLE
Build from jupyter/minimal-notebook to prevent using conda's R

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/r-notebook
+FROM jupyter/minimal-notebook
 MAINTAINER rowe@zatonovo.com
 
 USER root
@@ -37,11 +37,15 @@ EXPOSE 8004
 RUN apt-get install -y git
 RUN git clone https://github.com/muxspace/crant.git /app/crant
 ENV PATH="$PATH:/app/crant"
-
-RUN rpackage futile.logger futile.matrix 
+RUN rpackage futile.logger futile.matrix
 RUN rpackage formatR
 RUN rpackage https://github.com/zatonovo/lambda.r.git
 RUN rpackage https://github.com/zatonovo/lambda.tools.git
+
+# For R jupyter notebook
+RUN rpackage repr IRdisplay pbdZMQ uuid
+RUN rpackage https://github.com/IRkernel/IRkernel.git
+RUN Rscript -e "IRkernel::installspec()"
 
 RUN mkdir /app/cache
 

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -37,6 +37,7 @@ EXPOSE 8004
 RUN apt-get install -y git
 RUN git clone https://github.com/muxspace/crant.git /app/crant
 ENV PATH="$PATH:/app/crant"
+
 RUN rpackage futile.logger futile.matrix
 RUN rpackage formatR
 RUN rpackage https://github.com/zatonovo/lambda.r.git

--- a/images/Makefile
+++ b/images/Makefile
@@ -24,3 +24,5 @@ stop:
 bash:
 	docker exec -it ${CONTAINER_ID} bash
 
+jupyter: all
+	docker run -it -p 8888:8888 ${MOUNT_HOSDIR} -w /app/${PACKAGE} ${REPOSITORY} jupyter notebook --allow-root


### PR DESCRIPTION
There were conflicts when using opencpu with anaconda's R. The proposed solution is to use the system R rather than use anaconda's version of R. This is implemented by building from `jupyter/minimal-notebook` instead of `jupyter/r-notebook` and installing needed dependencies for `irkernel`.